### PR TITLE
Remove chemistry link from navbox

### DIFF
--- a/scripts/navbox.js
+++ b/scripts/navbox.js
@@ -131,7 +131,6 @@ let navbox = `
                     <li><a href="./">Main Page</a></li>
                     <li><a href="./honorcode.html">Honor Code</a></li>
                     <li><a href="./physical-science/">Apologia Physical Science</a></li>
-                    <li><a href="./chemistry/">Chemistry</a></li>
                 </ul>
             </div>`;
 


### PR DESCRIPTION
Properly orphans it. this is intentional.